### PR TITLE
docs: fix 'uses' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Uses the default command `up` and does not check in the database schema.
 ...
 steps:
   - name: "Run migrations"
-    uses: actions/dbmate-action@v1.15
+    uses: dwin/dbmate-action@v1.15
     with:
       command: 'up'
     env:
@@ -45,7 +45,7 @@ steps:
 ...
 steps:
   - name: "Run migrations"
-    uses: actions/dbmate-action@v1.15
+    uses: dwin/dbmate-action@v1.15
     with:
       command: 'up'
     env:


### PR DESCRIPTION
The readme had the incorrect `uses:` link, which if copied and pasted as-is resulted in this error in actions:

```
Error: Unable to resolve action actions/dbmate-action, repository not found
```